### PR TITLE
Make it possible to pass options to Hammer 🔨

### DIFF
--- a/src/components/ReactPullToRefresh.js
+++ b/src/components/ReactPullToRefresh.js
@@ -24,7 +24,8 @@ export default class ReactPullToRefresh extends Component {
         ptrEl: this.refs.ptr,
         distanceToRefresh: this.props.distanceToRefresh || undefined,
         loadingFunction: this.handleRefresh,
-        resistance: this.props.resistance || undefined
+        resistance: this.props.resistance || undefined,
+        hammerOptions: this.props.hammerOptions || undefined
       });
       this.setState({
         initialized: true
@@ -82,5 +83,6 @@ ReactPullToRefresh.propTypes = {
   className: PropTypes.string,
   style: PropTypes.object,
   distanceToRefresh: PropTypes.number,
-  resistance: PropTypes.number
+  resistance: PropTypes.number,
+  hammerOptions: PropTypes.object
 };

--- a/src/pull-to-refresh/wptr.1.1.js
+++ b/src/pull-to-refresh/wptr.1.1.js
@@ -56,14 +56,15 @@ export default function WebPullToRefresh() {
 			ptrEl: params.ptrEl || document.getElementById( defaults.ptrEl ),
 			distanceToRefresh: params.distanceToRefresh || defaults.distanceToRefresh,
 			loadingFunction: params.loadingFunction || defaults.loadingFunction,
-			resistance: params.resistance || defaults.resistance
+			resistance: params.resistance || defaults.resistance,
+			hammerOptions: params.hammerOptions || {}
 		};
 
 		if ( ! options.contentEl || ! options.ptrEl ) {
 			return false;
 		}
 
-		var h = new Hammer( options.contentEl );
+		var h = new Hammer( options.contentEl, options.hammerOptions );
 
 		h.get( 'pan' ).set( { direction: Hammer.DIRECTION_VERTICAL } );
 


### PR DESCRIPTION
Hammer sets a bunch of inline styles on the `.refresh-view` element.  With the default [`touchAction`](http://hammerjs.github.io/jsdoc/Hammer.defaults.html#.touchAction) I couldn't scroll my page at all.  It's overrideable but you need to be able to pass an options object to the Hammer constructor.

This commit allows users to pass an options object to the Hammer constructor.
