### PR TITLE
Ability to use more than one instance on page.

### DIFF
--- a/src/components/ReactPullToRefresh.js
+++ b/src/components/ReactPullToRefresh.js
@@ -22,6 +22,7 @@ export default class ReactPullToRefresh extends Component {
       WebPullToRefresh().init({
         contentEl: this.refs.refresh,
         ptrEl: this.refs.ptr,
+        bodyEl: this.refs.body,
         distanceToRefresh: this.props.distanceToRefresh || undefined,
         loadingFunction: this.handleRefresh,
         resistance: this.props.resistance || undefined,
@@ -62,7 +63,7 @@ export default class ReactPullToRefresh extends Component {
       </div>
     );
     return (
-      <div {...this.props}>
+      <div ref="body" {...this.props}>
         <div ref="ptr" className="ptr-element">
           {icon}
           {loading}

--- a/src/pull-to-refresh/wptr.1.1.js
+++ b/src/pull-to-refresh/wptr.1.1.js
@@ -13,6 +13,9 @@ export default function WebPullToRefresh() {
 		// ID of the element holding pull to refresh loading area
 		ptrEl: 'ptr',
 
+		// ID of the wrapper element holding scollable
+		bodyEl: 'body',
+
 		// Number of pixels of panning until refresh
 		distanceToRefresh: 70,
 
@@ -54,6 +57,7 @@ export default function WebPullToRefresh() {
 		options = {
 			contentEl: params.contentEl || document.getElementById( defaults.contentEl ),
 			ptrEl: params.ptrEl || document.getElementById( defaults.ptrEl ),
+			bodyEl: params.bodyEl || document.getElementById( defaults.bodyEl ),
 			distanceToRefresh: params.distanceToRefresh || defaults.distanceToRefresh,
 			loadingFunction: params.loadingFunction || defaults.loadingFunction,
 			resistance: params.resistance || defaults.resistance,
@@ -63,6 +67,8 @@ export default function WebPullToRefresh() {
 		if ( ! options.contentEl || ! options.ptrEl ) {
 			return false;
 		}
+
+		bodyClass = options.bodyEl.classList;
 
 		var h = new Hammer( options.contentEl, options.hammerOptions );
 

--- a/src/pull-to-refresh/wptr.1.1.js
+++ b/src/pull-to-refresh/wptr.1.1.js
@@ -86,7 +86,7 @@ export default function WebPullToRefresh() {
 	 * @param {object} e - Event object
 	 */
 	var _panStart = function(e) {
-		pan.startingPositionY = document.body.scrollTop;
+		pan.startingPositionY = options.bodyEl.scrollTop;
 
 		if ( pan.startingPositionY === 0 ) {
 			pan.enabled = true;
@@ -167,7 +167,7 @@ export default function WebPullToRefresh() {
 		options.contentEl.style.transform = options.contentEl.style.webkitTransform = '';
 		options.ptrEl.style.transform = options.ptrEl.style.webkitTransform = '';
 
-		if ( document.body.classList.contains( 'ptr-refresh' ) ) {
+		if ( options.bodyEl.classList.contains( 'ptr-refresh' ) ) {
 			_doLoading();
 		} else {
 			_doReset();
@@ -208,10 +208,10 @@ export default function WebPullToRefresh() {
 
 		var bodyClassRemove = function() {
 			bodyClass.remove( 'ptr-reset' );
-			document.body.removeEventListener( 'transitionend', bodyClassRemove, false );
+			options.bodyEl.removeEventListener( 'transitionend', bodyClassRemove, false );
 		};
 
-		document.body.addEventListener( 'transitionend', bodyClassRemove, false );
+		options.bodyEl.addEventListener( 'transitionend', bodyClassRemove, false );
 	};
 
 	return {

--- a/src/pull-to-refresh/wptr.1.1.js
+++ b/src/pull-to-refresh/wptr.1.1.js
@@ -13,8 +13,8 @@ export default function WebPullToRefresh() {
 		// ID of the element holding pull to refresh loading area
 		ptrEl: 'ptr',
 
-		// ID of the wrapper element holding scollable
-		bodyEl: 'body',
+		// wrapper element holding scollable
+		bodyEl: document.body,
 
 		// Number of pixels of panning until refresh
 		distanceToRefresh: 70,
@@ -45,7 +45,7 @@ export default function WebPullToRefresh() {
 	/**
 	 * Easy shortener for handling adding and removing body classes.
 	 */
-	var bodyClass = document.body.classList;
+	var bodyClass = defaults.bodyEl.classList;
 
 	/**
 	 * Initialize pull to refresh, hammer, and bind pan events.
@@ -57,7 +57,7 @@ export default function WebPullToRefresh() {
 		options = {
 			contentEl: params.contentEl || document.getElementById( defaults.contentEl ),
 			ptrEl: params.ptrEl || document.getElementById( defaults.ptrEl ),
-			bodyEl: params.bodyEl || document.getElementById( defaults.bodyEl ),
+			bodyEl: params.bodyEl || defaults.bodyEl,
 			distanceToRefresh: params.distanceToRefresh || defaults.distanceToRefresh,
 			loadingFunction: params.loadingFunction || defaults.loadingFunction,
 			resistance: params.resistance || defaults.resistance,


### PR DESCRIPTION
Hi, I would like to propose pull request with implemented ability to use more than one instance of react-pull-to-refresh on page. 

This is done by disconnecting wptr from document.body by adding bodyEl option attribute. react-pull-to-refresh wrapper then uses `this.refs.body` as `bodyEl` attribute.
