### PR TITLE
Stop React complaining about unknown props

### DIFF
--- a/src/components/ReactPullToRefresh.js
+++ b/src/components/ReactPullToRefresh.js
@@ -47,29 +47,39 @@ export default class ReactPullToRefresh extends Component {
   }
 
   render() {
-    if (this.props.disabled) {
+    const {
+      children,
+      disabled,
+      distanceToRefresh,
+      hammerOptions,
+      icon,
+      loading,
+      onRefresh,
+      resistance,
+      ...rest
+    } = this.props;
+
+    if (disabled) {
       return (
-        <div {...this.props}>
-          {this.props.children}
+        <div {...rest}>
+          {children}
         </div>
       );
     }
-    let icon = this.props.icon || <span className="genericon genericon-next"></span>;
-    let loading = this.props.loading || (
-      <div className="loading">
-        <span className="loading-ptr-1"></span>
-        <span className="loading-ptr-2"></span>
-        <span className="loading-ptr-3"></span>
-      </div>
-    );
+
     return (
-      <div ref="body" {...this.props}>
+      <div ref="body" {...rest}>
         <div ref="ptr" className="ptr-element">
-          {icon}
-          {loading}
+          {icon || <span className="genericon genericon-next"></span>}
+          {loading ||
+            <div className="loading">
+              <span className="loading-ptr-1"></span>
+              <span className="loading-ptr-2"></span>
+              <span className="loading-ptr-3"></span>
+           </div>}
         </div>
         <div ref="refresh" className="refresh-view">
-          {this.props.children}
+          {children}
         </div>
       </div>
     );


### PR DESCRIPTION
React was yelling at me for using this component in a new project:

```
main.js:7426 Warning: Unknown props `onRefresh`, `distanceToRefresh`, `loading`, `hammerOptions` on <div> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
    in div (created by ReactPullToRefresh)
    in ReactPullToRefresh (created by Dashboard)
    in Dashboard (created by Connect(Dashboard))
    in Connect(Dashboard) (created by RouterContext)
    in div (created by App)
    in App (created by RouterContext)
    in RouterContext (created by Router)
    in Router (created by Root)
    in div (created by Root)
    in Provider (created by Root)
    in Root
```

If you visit [that link](https://fb.me/react-unknown-prop) it explains that as of a few days ago React will check that attributes and properties on DOM elements are valid.

This fix is not ideal because there are now a bunch of unused variables in the render method, but I can't think of a better way that still allows use of the object spread operator for transferring arbitrary props to the wrapper div.

Anyway, I thought this would be more constructive than posting an issue!
