### PR TITLE
Fix refs to use functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "react-pull-to-refresh",
+  "name": "@benogle/react-pull-to-refresh",
   "version": "1.1.1",
   "description": "A React component for pull to refresh on the web.",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bryaneaton13/react-pull-to-refresh.git"
+    "url": "https://github.com/benogle/react-pull-to-refresh.git"
   },
   "homepage": "",
-  "bugs": "https://github.com/bryaneaton13/react-pull-to-refresh/issues",
+  "bugs": "https://github.com/benogle/react-pull-to-refresh/issues",
   "directories": {
     "example": "examples"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benogle/react-pull-to-refresh",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A React component for pull to refresh on the web.",
   "main": "./lib/index.js",
   "repository": {

--- a/src/components/ReactPullToRefresh.js
+++ b/src/components/ReactPullToRefresh.js
@@ -21,9 +21,9 @@ export default class ReactPullToRefresh extends Component {
   init() {
     if (!this.state.initialized) {
       WebPullToRefresh().init({
-        contentEl: this.refs.refresh,
-        ptrEl: this.refs.ptr,
-        bodyEl: this.refs.body,
+        contentEl: this.refresh,
+        ptrEl: this.ptr,
+        bodyEl: this.body,
         distanceToRefresh: this.props.distanceToRefresh || undefined,
         loadingFunction: this.handleRefresh,
         resistance: this.props.resistance || undefined,
@@ -69,8 +69,8 @@ export default class ReactPullToRefresh extends Component {
     }
 
     return (
-      <div ref="body" {...rest}>
-        <div ref="ptr" className="ptr-element">
+      <div ref={(el) => { this.body = el; }} {...rest}>
+        <div ref={(el) => { this.ptr = el; }} className="ptr-element">
           {icon || <span className="genericon genericon-next"></span>}
           {loading ||
             <div className="loading">
@@ -79,7 +79,7 @@ export default class ReactPullToRefresh extends Component {
               <span className="loading-ptr-3"></span>
            </div>}
         </div>
-        <div ref="refresh" className="refresh-view">
+        <div ref={(el) => { this.refresh = el; }} className="refresh-view">
           {children}
         </div>
       </div>


### PR DESCRIPTION
String refs were causing problems in our webapp. This fixes them, and has no effect on functionality.